### PR TITLE
fix: Add TensorBoard Support and append the loss

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ torch==1.12.0+cu116
 --extra-index-url https://download.pytorch.org/whl/cu116
 dill==0.3.9
 tqdm==4.67.1
+tensorboard==2.17.0


### PR DESCRIPTION
This pull request enhances the training script in `MoMKE/train_MoMKE.py` by integrating TensorBoard logging for better experiment tracking and visualization. It also improves the calculation of average loss to ensure correctness. 

**TensorBoard Integration:**

* Added TensorBoard support by importing `SummaryWriter`, creating a log directory, and initializing a writer instance for each run. This enables logging of training metrics for visualization. 
* Logged key metrics (accuracy, loss, MAE, F1-score, correlation) for both training and testing phases at each epoch to TensorBoard, for both first and second training stages.

**Loss Calculation Improvements:**

* Modified batch loss accumulation to correctly handle averaging over valid samples, preventing double division by the mask count and ensuring accurate average loss computation.
* Updated the calculation of `avg_loss` to handle cases where the `losses` array is empty, avoiding division by zero errors. 